### PR TITLE
Fix error in return type of fstat

### DIFF
--- a/reference/filesystem/functions/fstat.xml
+++ b/reference/filesystem/functions/fstat.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>fstat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>fstat</methodname>
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -39,6 +39,7 @@
   <para>
    Retorna um array com as estatísticas de um arquivo. O formato do array
    é descrito em detalhes na página do manual sobre <function>stat</function>.
+   Em caso de erro, <function>fstat</function> retorna &false;.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Currently, the translated PHP documentation does not say that fstat can return a false in case of error. This is correct in the English version https://www.php.net/fstat